### PR TITLE
feat: add CUDA to the default list

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,5 @@
   entry: clang-format
   args: [-style=file, -i]
   language: python
-  types_or: [c++, c, c#]
-  minimum_pre_commit_version: 2.9.0
+  types_or: [c++, c, c#, cuda]
+  minimum_pre_commit_version: 2.9.2


### PR DESCRIPTION
There's a long list of supported languages (C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C#), but some of them might be surprising (like JSON & .m files for Objective C), but CUDA's one that probably would be expected along with the normal C family. Users can always override, but having CUDA in the default set seems like a good idea.

Also implemented in https://github.com/pre-commit/mirrors-clang-format/pull/1.

Also fixing the min version to be a little better for types-or support.